### PR TITLE
Migrating to optax: DQN and Rainbow

### DIFF
--- a/lifting_veil/agents/dqn_agent_new.py
+++ b/lifting_veil/agents/dqn_agent_new.py
@@ -37,10 +37,6 @@ def mse_loss(targets, predictions):
     return jnp.mean(jnp.power((targets - (predictions)), 2))
 
 
-#@functools.partial(jax.jit, static_argnums=(0, 9, 10, 11, 12, 13, 14))
-#def train(network_def, target_params, optimizer, states, actions, next_states, rewards, terminals, loss_weights,
-#          cumulative_gamma, target_opt, mse_inf, tau, alpha, clip_value_min, rng):
-
 @functools.partial(jax.jit, static_argnums=(0, 3, 11, 12, 13, 14, 15, 16))
 def train(network_def, online_params, target_params, optimizer, optimizer_state, states, actions, next_states, rewards, terminals, loss_weights,
           cumulative_gamma, target_opt, mse_inf, tau, alpha, clip_value_min, rng):
@@ -319,6 +315,7 @@ class JaxDQNAgentNew(dqn_agent.JaxDQNAgent):
                     self.network_def,
                     self.online_params,
                     self.target_network_params,
+                    self.optimizer,
                     self.optimizer_state, 
                     self.replay_elements['state'],
                     self.replay_elements['action'],

--- a/lifting_veil/agents/dqn_agent_new.py
+++ b/lifting_veil/agents/dqn_agent_new.py
@@ -31,17 +31,20 @@ import numpy as onp
 import tensorflow as tf
 import jax.scipy.special as scp
 from flax import linen as nn
-
+import optax
 
 def mse_loss(targets, predictions):
     return jnp.mean(jnp.power((targets - (predictions)), 2))
 
 
-@functools.partial(jax.jit, static_argnums=(0, 9, 10, 11, 12, 13, 14))
-def train(network_def, target_params, optimizer, states, actions, next_states, rewards, terminals, loss_weights,
+#@functools.partial(jax.jit, static_argnums=(0, 9, 10, 11, 12, 13, 14))
+#def train(network_def, target_params, optimizer, states, actions, next_states, rewards, terminals, loss_weights,
+#          cumulative_gamma, target_opt, mse_inf, tau, alpha, clip_value_min, rng):
+
+@functools.partial(jax.jit, static_argnums=(0, 3, 11, 12, 13, 14, 15, 16))
+def train(network_def, online_params, target_params, optimizer, optimizer_state, states, actions, next_states, rewards, terminals, loss_weights,
           cumulative_gamma, target_opt, mse_inf, tau, alpha, clip_value_min, rng):
     """Run the training step."""
-    online_params = optimizer.target
 
     def loss_fn(params, rng_input, target, loss_multipliers):
 
@@ -83,8 +86,9 @@ def train(network_def, target_params, optimizer, states, actions, next_states, r
 
     grad_fn = jax.value_and_grad(loss_fn, has_aux=True)
     (mean_loss, loss), grad = grad_fn(online_params, rng3, target, loss_weights)
-    optimizer = optimizer.apply_gradient(grad)
-    return optimizer, loss, mean_loss
+    updates, optimizer_state = optimizer.update(grad, optimizer_state)
+    online_params = optax.apply_updates(online_params, updates)
+    return optimizer_state, online_params, loss
 
 
 def target_DDQN(model, target_network, next_states, rewards, terminals, cumulative_gamma):
@@ -270,10 +274,10 @@ class JaxDQNAgentNew(dqn_agent.JaxDQNAgent):
 
     def _build_networks_and_optimizer(self):
         self._rng, rng = jax.random.split(self._rng)
-        online_network_params = self.network_def.init(rng, x=self.state, rng=self._rng)
-        optimizer_def = dqn_agent.create_optimizer(self._optimizer_name)
-        self.optimizer = optimizer_def.create(online_network_params)
-        self.target_network_params = copy.deepcopy(online_network_params)
+        self.online_params = self.network_def.init(rng, x=self.state, rng=self._rng)
+        self.optimizer = create_optimizer(self._optimizer_name)
+        self.optimizer_state = self.optimizer.init(self.online_params)
+        self.target_network_params = copy.deepcopy(self.online_params)
 
     def _build_replay_buffer(self):
         """Creates the prioritized replay buffer used by the agent."""
@@ -311,11 +315,24 @@ class JaxDQNAgentNew(dqn_agent.JaxDQNAgent):
                 else:
                     loss_weights = jnp.ones(self.replay_elements['state'].shape[0])
 
-                self.optimizer, loss, mean_loss = train(
-                    self.network_def, self.target_network_params, self.optimizer, self.replay_elements['state'],
-                    self.replay_elements['action'], self.replay_elements['next_state'], self.replay_elements['reward'],
-                    self.replay_elements['terminal'], loss_weights, self.cumulative_gamma, self._target_opt,
-                    self._mse_inf, self._tau, self._alpha, self._clip_value_min, self._rng)
+                self.optimizer_state, self.online_params, loss = train(
+                    self.network_def,
+                    self.online_params,
+                    self.target_network_params,
+                    self.optimizer_state, 
+                    self.replay_elements['state'],
+                    self.replay_elements['action'],
+                    self.replay_elements['next_state'],
+                    self.replay_elements['reward'],
+                    self.replay_elements['terminal'],
+                    loss_weights,
+                    self.cumulative_gamma,
+                    self._target_opt,
+                    self._mse_inf,
+                    self._tau,
+                    self._alpha,
+                    self._clip_value_min,
+                    self._rng)
 
                 if self._replay_scheme == 'prioritized':
                     # Rainbow and prioritized replay are parametrized by an exponent

--- a/lifting_veil/agents/rainbow_agent_new.py
+++ b/lifting_veil/agents/rainbow_agent_new.py
@@ -24,13 +24,18 @@ import jax
 import jax.numpy as jnp
 import numpy as onp
 import tensorflow as tf
+import optax
 
+#@functools.partial(jax.jit, static_argnums=(0, 10, 11))
+#def train(network_def, target_params, optimizer, states, actions, next_states, rewards,
+#          terminals, loss_weights, support, cumulative_gamma, double_dqn, rng):
 
-@functools.partial(jax.jit, static_argnums=(0, 10, 11))
-def train(network_def, target_params, optimizer, states, actions, next_states, rewards,
+@functools.partial(jax.jit, static_argnums=(0, 3, 12, 13))
+def train(network_def, online_params, target_params, optimizer, optimizer_state, states, actions, next_states, rewards,
           terminals, loss_weights, support, cumulative_gamma, double_dqn, rng):
   """Run a training step."""
-  online_params = optimizer.target
+  """Run a training step."""
+
   def loss_fn(params, rng_input, target, loss_multipliers):
     def q_online(state):
       return network_def.apply(params, state, support, rng=rng_input)
@@ -61,8 +66,10 @@ def train(network_def, target_params, optimizer, states, actions, next_states, r
   
   # Get the unweighted loss without taking its mean for updating priorities.
   (mean_loss, loss), grad = grad_fn(online_params, rng3, target, loss_weights)
+  updates, optimizer_state = optimizer.update(grad, optimizer_state)
+  online_params = optax.apply_updates(online_params, updates)
   optimizer = optimizer.apply_gradient(grad)
-  return optimizer, loss, mean_loss
+  return optimizer_state, online_params, loss, mean_loss
 
 
 @functools.partial(jax.vmap, in_axes=(None, None, 0, 0, 0, None, None))
@@ -229,10 +236,12 @@ class JaxRainbowAgentNew(dqn_agent.JaxDQNAgent):
 
   def _build_networks_and_optimizer(self):
     self._rng, rng = jax.random.split(self._rng)
-    online_network_params = self.network_def.init(rng, x=self.state, support=self._support, rng=self._rng)
-    optimizer_def = dqn_agent.create_optimizer(self._optimizer_name)
-    self.optimizer = optimizer_def.create(online_network_params)
-    self.target_network_params = copy.deepcopy(online_network_params)
+    self.online_params = self.network_def.init(rng, x=self.state,
+                                               support=self._support, 
+                                               rng=self._rng)
+    self.optimizer = dqn_agent.create_optimizer(self._optimizer_name)
+    self.optimizer_state = self.optimizer.init(self.online_params)
+    self.target_network_params = copy.deepcopy(self.online_params)
 
 
   def _build_replay_buffer(self):
@@ -322,10 +331,12 @@ class JaxRainbowAgentNew(dqn_agent.JaxDQNAgent):
         else:
           loss_weights = jnp.ones(self.replay_elements['state'].shape[0])
 
-        self.optimizer, loss, mean_loss = train(
+        (self.optimizer_state, self.online_params, loss, mean_loss) = train(
             self.network_def,
+            self.online_params,
             self.target_network_params,
             self.optimizer,
+            self.optimizer_state,
             self.replay_elements['state'],
             self.replay_elements['action'],
             self.replay_elements['next_state'],

--- a/lifting_veil/agents/rainbow_agent_new.py
+++ b/lifting_veil/agents/rainbow_agent_new.py
@@ -26,14 +26,9 @@ import numpy as onp
 import tensorflow as tf
 import optax
 
-#@functools.partial(jax.jit, static_argnums=(0, 10, 11))
-#def train(network_def, target_params, optimizer, states, actions, next_states, rewards,
-#          terminals, loss_weights, support, cumulative_gamma, double_dqn, rng):
-
 @functools.partial(jax.jit, static_argnums=(0, 3, 12, 13))
 def train(network_def, online_params, target_params, optimizer, optimizer_state, states, actions, next_states, rewards,
           terminals, loss_weights, support, cumulative_gamma, double_dqn, rng):
-  """Run a training step."""
   """Run a training step."""
 
   def loss_fn(params, rng_input, target, loss_multipliers):
@@ -68,7 +63,6 @@ def train(network_def, online_params, target_params, optimizer, optimizer_state,
   (mean_loss, loss), grad = grad_fn(online_params, rng3, target, loss_weights)
   updates, optimizer_state = optimizer.update(grad, optimizer_state)
   online_params = optax.apply_updates(online_params, updates)
-  optimizer = optimizer.apply_gradient(grad)
   return optimizer_state, online_params, loss, mean_loss
 
 
@@ -331,7 +325,7 @@ class JaxRainbowAgentNew(dqn_agent.JaxDQNAgent):
         else:
           loss_weights = jnp.ones(self.replay_elements['state'].shape[0])
 
-        (self.optimizer_state, self.online_params, loss, mean_loss) = train(
+        self.optimizer_state, self.online_params, loss, mean_loss = train(
             self.network_def,
             self.online_params,
             self.target_network_params,


### PR DESCRIPTION
Migrating to optax: DQN and Rainbow:

1. add import optax
2. update _build_networks_and_optimizer function
3. add self.online_params and self.optimizer_state to call to train, and receive optimizer_state and online_params
4. change train signature so it accepts online_params and optimizer_state, and update the static_argnums in the jit decorator
5. update the way you apply the gradients (two lines instead of one)
6. return optimizer_state and online_params from train